### PR TITLE
fixes 'D' being an unidentified command

### DIFF
--- a/JumpingSkills.cpp
+++ b/JumpingSkills.cpp
@@ -66,7 +66,7 @@ void JumpingSkills::Event (bz_EventData *eventData)
 
 bool JumpingSkills::SlashCommand(int playerID, bz_ApiString command, bz_ApiString /*message*/, bz_APIStringList *params)
 {
-    if (command == "d")
+    if (command == "d" || command == "D")
     {
         bz_killPlayer(playerID, false);
 


### PR DESCRIPTION
When '/D' is typed in as a slash command, it causes the command to be unidentified.
The following pull request fixes this with an 'or' statement being added to the logic.
